### PR TITLE
Fix error returned when fetching ClouDNS zone with incorrect auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE_NAME := "ixoncloud/cert-manager-webhook-cloudns"
-IMAGE_TAG := "1.0.2"
+IMAGE_TAG := "1.0.3"
 
 OUT := $(shell pwd)/.out
 

--- a/cloudns/internal/client.go
+++ b/cloudns/internal/client.go
@@ -21,10 +21,11 @@ type apiResponse struct {
 }
 
 type Zone struct {
-	Name   string
-	Type   string
-	Zone   string
-	Status string // is an integer, but cast as string
+	Name              string
+	Type              string
+	Zone              string
+	Status            string // is an integer, but cast as string
+	StatusDescription string
 }
 
 // TXTRecord a TXT record
@@ -98,6 +99,11 @@ func (c *Client) GetZone(authFQDN string) (*Zone, error) {
 		if err = json.Unmarshal(result, &zone); err != nil {
 			return nil, fmt.Errorf("zone unmarshaling error: %v", err)
 		}
+	}
+
+	// Handle zone info fail
+	if zone.Status == "Failed" {
+		return nil, fmt.Errorf("could not get zone info: %v", zone.StatusDescription)
 	}
 
 	if zone.Name == authZoneName {

--- a/deploy/cert-manager-webhook-cloudns/Chart.yaml
+++ b/deploy/cert-manager-webhook-cloudns/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0.2"
+appVersion: "1.0.3"
 description: A helm chart for cert-manager-webhook-cloudns
 name: cert-manager-webhook-cloudns
 version: 1.0.0

--- a/deploy/cert-manager-webhook-cloudns/values.yaml
+++ b/deploy/cert-manager-webhook-cloudns/values.yaml
@@ -11,7 +11,7 @@ certManager:
 
 image:
   repository: ixoncloud/cert-manager-webhook-cloudns
-  tag: 1.0.2
+  tag: 1.0.3
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
Without this fix, the error returned by ClouDNS was being parsed as a non-error response as ClouDNS returns a `200` status in the case of an authentication failure.